### PR TITLE
[Space] Avoid sending auto apod on reload and restart if actual apod has been already sent

### DIFF
--- a/space/core.py
+++ b/space/core.py
@@ -73,8 +73,10 @@ class Core:
                 all_channels = await self.config.all_channels()
                 for channels in all_channels.items():
                     if channels[1]["auto_apod"]:
-                        channel = bot.get_channel(id=channels[0])
-                        await self.maybe_send_embed(channel, await self.apod_text(data))
+                        if channels[1]["last_apod_sent"] != data["date"]:
+                            channel = bot.get_channel(id=channels[0])
+                            await self.maybe_send_embed(channel, await self.apod_text(data))
+                            await self.config.channel(channel).last_apod_sent.set(data["date"])
                 self.cache["date"] = data["date"]
             else:
                 await asyncio.sleep(900)

--- a/space/space.py
+++ b/space/space.py
@@ -22,7 +22,7 @@ class Space(Core, commands.Cog):
         self.bot = bot
         self.cache = {"date": None, "new_channels": []}
 
-        default_channel = dict(auto_apod=False)
+        default_channel = dict(auto_apod=False, last_apod_sent=None)
         self.config = Config.get_conf(self, 3765640575174574082, force_registration=True)
         self.config.register_channel(**default_channel)
 


### PR DESCRIPTION
This PR add a little config var that set the date of last apod sent, this is to avoid sending apod if it has already been sent in the channel when you reload the cog or restart the bot.