### PR TITLE
`required_cogs` in `info.json` file should be a dict not list

### DIFF
--- a/ark/info.json
+++ b/ark/info.json
@@ -17,7 +17,7 @@
         2
     ],
     "name": "ark",
-    "required_cogs": [],
+    "required_cogs": {},
     "requirements": [],
     "short": "Retrieves info from Intel's ARK database.",
     "tags": [],


### PR DESCRIPTION
According to docs:
> `required_cogs` (map of cogname to repo URL) - A map of required cogs that this cog depends on.

This means `required_cogs` should be a dict, not a list.