### PR TITLE
[Imperial Toolkit] Fetch CPU model info correctly

### DIFF
--- a/imperialtoolkit/imperialtoolkit.py
+++ b/imperialtoolkit/imperialtoolkit.py
@@ -123,7 +123,7 @@ class ImperialToolkit(commands.Cog):
                 osver = "Could not parse OS, report this on Github."
 
             try:
-                cpu = cpuinfo.get_cpu_info()["brand"]
+                cpu = cpuinfo.get_cpu_info()["brand_raw"]
             except:
                 cpu = "unknown"
             cpucount = psutil.cpu_count()


### PR DESCRIPTION
Currently, the cog tries to fetch `brand` key from `get_cpu_info()` method when trying to get the CPU model info, but the correct name of the key it should fetch is `brand_raw`.

You can verify this yourself with the following in your python interpreter or with an eval:
```py
from cpuinfo import get_cpu_info

for key, value in get_cpu_info().items():
    print("{0}: {1}".format(key, value))
```

In the returned output from above call, you will see there is no `brand` key but instead, the value of CPU model info is returned in `brand_raw` key. I have tested this with my instance which works. Please let me know what do you think. 