### PR TITLE
[Space] adds image credits in footer for [p]apod

### DIFF
--- a/space/core.py
+++ b/space/core.py
@@ -126,7 +126,7 @@ class Core(commands.Cog):
             )
             em.set_image(url=data["url"])
             em.add_field(name=data["title"], value=details)
-            em.set_footer(text="Today is {}".format(data["date"]))
+            em.set_footer(text="Image Credits: {} • Today is {}".format(data["copyright"], data["date"]))
             return em
 
     @staticmethod

--- a/space/core.py
+++ b/space/core.py
@@ -121,7 +121,7 @@ class Core(commands.Cog):
                 color=await self.bot.get_embed_color(context)
                 if hasattr(self.bot, "get_embed_color")
                 else self.bot.color,
-                title="Astronomy Picture of the Day",
+                title=data["title"],
                 url="{}".format(data["url"]),
             )
             em.set_author(
@@ -130,7 +130,7 @@ class Core(commands.Cog):
                 icon_url="https://i.imgur.com/Wh8jY9c.png",
             )
             em.set_image(url=data["url"])
-            em.add_field(name=data["title"], value=details)
+            em.add_field(name="\u200b", value=details)
             em.set_footer(text="Image Credits: {} • Today is {}".format(data["copyright"], data["date"]))
             return em
 

--- a/space/core.py
+++ b/space/core.py
@@ -124,6 +124,11 @@ class Core(commands.Cog):
                 title="Astronomy Picture of the Day",
                 url="{}".format(data["url"]),
             )
+            em.set_author(
+                name="Astronomy Picture of the Day",
+                url="https://apod.nasa.gov/apod/astropix.html",
+                icon_url="https://i.imgur.com/Wh8jY9c.png",
+            )
             em.set_image(url=data["url"])
             em.add_field(name=data["title"], value=details)
             em.set_footer(text="Image Credits: {} • Today is {}".format(data["copyright"], data["date"]))


### PR DESCRIPTION
What PR title says. Please let me know what do you think!

Preview:
https://i.imgur.com/ecqoYwH.png
![XNFLSdC](https://user-images.githubusercontent.com/24418520/91032776-142c2200-e620-11ea-9494-351d654ed3ed.png)

About the second commit which was requested by Preda, source message: https://discord.com/channels/133049272517001216/133251234164375552/747400847054602304

The resulting embed will look like this, if this PR is merged:
![Screenshot_20200824-174947_Discord](https://user-images.githubusercontent.com/24418520/91044164-79890e80-e632-11ea-9430-1b356c462a1b.png)
