### PR TITLE
[Space] Don't disable auto APOD if channel is None

### DIFF
--- a/space/core.py
+++ b/space/core.py
@@ -57,7 +57,6 @@ class Core(commands.Cog):
                         if channels[1]["last_apod_sent"] != data["date"]:
                             channel = self.bot.get_channel(channels[0])
                             if not channel:
-                                await self.config.channel_from_id(channels[0]).auto_apod.set(False)
                                 continue
                             await self.maybe_send_embed(
                                 channel, await self.apod_text(data, channel)


### PR DESCRIPTION
In some cases like the guild being unavailable the channel can be None and then is disabled, which isn't what we want.