### PR TITLE
feat(lastfm): Remove play count.

### DIFF
--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -113,15 +113,6 @@ class LastFM(BaseCog):
                 tags = await self._api_request(method='track.getTopTags', track=song, artist=artist, autocorrect=1)
                 trackinfo = await self._api_request(method='track.getInfo', track=song, artist=artist, username=username)
 
-                try:
-                    if 'userplaycount' in trackinfo['track']:
-                        playcount = trackinfo['track']['userplaycount']
-                    else:
-                        playcount = '0'
-                except:
-                    playcount = '0'
-                    pass
-
                 if 'error' not in tags:
                     tags = ', '.join(['[{}]({})'.format(tag['name'], tag['url']) for tag in tags['toptags']['tag'][:10]])
                 else:
@@ -135,7 +126,6 @@ class LastFM(BaseCog):
                 em.set_thumbnail(url=image)
                 em.add_field(name=_('**Artist**'), value='[{}]({})'.format(artist, artist_url))
                 em.add_field(name=_('**Track**'), value='[{}]({})'.format(song, track_url))
-                em.add_field(name=_('**Playcount**'), value='{}'.format(playcount))
                 em.add_field(name=_('**Album**'), value='[{}]({})'.format(album, album_url))
                 if tags:
                     em.add_field(name=_('**Tags**'), value=tags, inline=False)


### PR DESCRIPTION
Play count has been seen to be highly unreliable, and uses up space in the embed, causing other fields to be unnecessarily truncated.