### PR TITLE
[Space] Be less spammy to the API, and a few fixes

### DIFF
--- a/space/info.json
+++ b/space/info.json
@@ -1,6 +1,7 @@
 {
 	"author": [
-		"kennnyshiwa"
+		"kennnyshiwa",
+		"Predä"
 	],
 	"description": "Displays various pictures and other information about space",
 	"hidden": false,


### PR DESCRIPTION
- Removes the "new channels cache" and its task. Instead it directly send to new channels when using the command.
- Auto apod task is now every hour, instead of every 15 minutes. Also raise an exception when there's no data instead of `continue` which was not doing the asyncio.sleep properly.
- Updated `[p]apod` to the new API link.
- I added myself to cog authors.