### PR TITLE
Add Spotify URL to nowplaying message

### DIFF
--- a/lastfm/__init__.py
+++ b/lastfm/__init__.py
@@ -5,5 +5,6 @@ __red_end_user_data_statement__ = (
     "This will wipe their saved username from the cog"
 )
 
+
 def setup(bot):
     bot.add_cog(LastFM(bot))

--- a/lastfm/info.json
+++ b/lastfm/info.json
@@ -3,5 +3,6 @@
   "bot_version" : [3, 0, 0],
   "description" : "Last.fm playing",
   "short" : "Get currently playing and recently played tracks from Last.fm",
-  "tags" : ["last.fm", "lastfm", "paddo", "music"]
+  "tags" : ["last.fm", "lastfm", "paddo", "music"],
+  "requirements": ["bs4"]
 }

--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -75,7 +75,7 @@ class LastFM(BaseCog):
         await session.close()
         return data
 
-    async def _get_spotify_url(self, track_url: str) -> str:
+    async def _get_spotify_uri(self, track_url: str) -> str:
         """Fetches the spotify URI from the LastFM track information page"""
         async with aiohttp.ClientSession() as session:
             async with session.get(track_url) as response:

--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -129,7 +129,7 @@ class LastFM(BaseCog):
             if not spotify_url:
                 return
 
-            emote = await self.config.guild(ctx.guild).emote()
+            emote = await self.config.guild(ctx.guild).emote() if ctx.guild else "🎵"
             start_adding_reactions(msg, (emote))
             predicate = ReactionPredicate.with_emojis((emote), msg)
             reaction, user = await ctx.bot.wait_for("reaction_add", check=predicate)

--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -140,11 +140,14 @@ class LastFM(BaseCog):
                 em.set_thumbnail(url=image)
                 em.add_field(name=_('**Artist**'), value='[{}]({})'.format(artist, artist_url))
                 em.add_field(name=_('**Album**'), value='[{}]({})'.format(album, album_url))
-                em.add_field(name="\u200B", value="\u200B") # Blank field
-                em.add_field(name=_('**Track**'), value='[{}]({})'.format(song, track_url))
+                if spotify_uri:
+                    em.add_field(name="\u200B", value="\u200B") # Blank field
+                em.add_field(name=_('**Track**'), value='[{}]({})'.format(song, track_url), inline=True if spotify_uri else False)
+                if spotify_uri:
+                    em.add_field(name='**Spotify**', value='[Listen]({})'.format(spotify_uri))
                 if tags:
                     em.add_field(name=_('**Tags**'), value=tags, inline=False)
-                await ctx.send(content=spotify_uri, embed=em)
+                await ctx.send(embed=em)
         else:
             await ctx.send(_('{} is not playing any song right now').format(user))
 

--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -140,11 +140,9 @@ class LastFM(BaseCog):
                 em.set_thumbnail(url=image)
                 em.add_field(name=_('**Artist**'), value='[{}]({})'.format(artist, artist_url))
                 em.add_field(name=_('**Album**'), value='[{}]({})'.format(album, album_url))
+                em.add_field(name=_('**Track**'), value='[{}]({})'.format(song, track_url), inline=False)
                 if spotify_uri:
-                    em.add_field(name="\u200B", value="\u200B") # Blank field
-                em.add_field(name=_('**Track**'), value='[{}]({})'.format(song, track_url), inline=True if spotify_uri else False)
-                if spotify_uri:
-                    em.add_field(name='**Spotify**', value='[Listen]({})'.format(spotify_uri))
+                    em.add_field(name='**Spotify**', value='[Listen]({})'.format(spotify_uri), inline=False)
                 if tags:
                     em.add_field(name=_('**Tags**'), value=tags, inline=False)
                 await ctx.send(embed=em)

--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -13,7 +13,7 @@ from redbot.core.i18n import Translator
 from redbot.core.utils.menus import start_adding_reactions
 from redbot.core.utils.predicates import ReactionPredicate
 
-_ = Translator('Last_FM', __file__)
+_ = Translator("Last_FM", __file__)
 
 BaseCog = getattr(commands, "Cog", object)
 
@@ -22,7 +22,7 @@ BaseCog = getattr(commands, "Cog", object)
 
 
 class LastFM(BaseCog):
-    
+
     default_member_settings = {"username": ""}
 
     default_user_settings = default_member_settings
@@ -36,37 +36,202 @@ class LastFM(BaseCog):
         self.config.register_user(**self.default_user_settings)
         self.config.register_guild(**self.default_guild_settings)
 
-        self.lf_gateway = 'http://ws.audioscrobbler.com/2.0/'
+        self.lf_gateway = "http://ws.audioscrobbler.com/2.0/"
 
         self.payload = {}
-        self.payload['api_key'] = 'c44979d5d86ff515ba9fba378c610474'
-        self.payload['format'] = 'json'
+        self.payload["api_key"] = "c44979d5d86ff515ba9fba378c610474"
+        self.payload["format"] = "json"
 
+    @commands.command(name="nowplaying")
+    async def _nowplaying(self, ctx):
+        """Shows the current played song"""
+        username = await self.config.user(ctx.author).username()
 
-    async def _url_decode(self, url):
-        # Fuck non-ascii URLs!!!@##$@
-        url = urllib.parse.urlparse(url)
-        url = '{0.scheme}://{0.netloc}{1}'.format(url, urllib.parse.quote(url.path))
-        return url
+        if username == "":
+            return await ctx.send("You need to set a username first")
 
-    async def _api_request(self, method=None, username=None, limit=None, artist=None, track=None, mbid=None, autocorrect=None):
+        method = "user.getRecentTracks"
+        limit = 1
+        response = await self._api_request(
+            method=method, username=username, limit=limit
+        )
+        user = response["recenttracks"]["@attr"]["user"]
+
+        if response["recenttracks"]["track"] == []:
+            print(response["recenttracks"]["track"])
+            return await ctx.send(
+                "{} is not playing anything, check to make sure you set the right lastfm username".format(
+                    user
+                )
+            )
+
+        track = response["recenttracks"]["track"][0]
+
+        if "@attr" not in track:
+            await ctx.send(_("{} is not playing any song right now").format(user))
+            return
+
+        if track["@attr"]["nowplaying"] == "true":
+            artist = track["artist"]["#text"]
+            artist_url = await self._url_decode(
+                "https://www.last.fm/music/{}".format(artist.replace(" ", "+"))
+            )
+            song = track["name"]
+            track_url = await self._url_decode(track["url"])
+
+            album = track["album"]["#text"]
+            album_url = await self._url_decode(
+                "https://www.last.fm/music/{}/{}".format(
+                    artist.replace(" ", "+"), album.replace(" ", "+")
+                )
+            )
+
+            image = track["image"][-1]["#text"]
+            tags = await self._api_request(
+                method="track.getTopTags", track=song, artist=artist, autocorrect=1
+            )
+            trackinfo = await self._api_request(
+                method="track.getInfo", track=song, artist=artist, username=username
+            )
+
+            if "error" not in tags:
+                tags = ", ".join(
+                    [
+                        "[{}]({})".format(tag["name"], tag["url"])
+                        for tag in tags["toptags"]["tag"][:10]
+                    ]
+                )
+            else:
+                tags = None
+
+            song = [song if len(song) < 18 else song[:18] + "..."][0]
+            artist = [artist if len(artist) < 18 else artist[:18] + "..."][0]
+            album = [album if len(album) < 18 else album[:18] + "..."][0]
+            spotify_url = await self._get_spotify_url(track_url)
+
+            em = discord.Embed()
+            em.set_thumbnail(url=image)
+            em.add_field(
+                name=_("**Artist**"), value="[{}]({})".format(artist, artist_url)
+            )
+            em.add_field(name=_("**Album**"), value="[{}]({})".format(album, album_url))
+            em.add_field(
+                name=_("**Track**"),
+                value="[{}]({})".format(song, track_url),
+                inline=False,
+            )
+
+            if tags:
+                em.add_field(name=_("**Tags**"), value=tags, inline=False)
+
+            msg = await ctx.send(embed=em)
+
+            if not spotify_url:
+                return
+
+            emote = await self.config.guild(ctx.guild).emote()
+            start_adding_reactions(msg, (emote))
+            predicate = ReactionPredicate.with_emojis((emote), msg)
+            reaction, user = await ctx.bot.wait_for("reaction_add", check=predicate)
+
+            if predicate.result == 0:
+                await msg.clear_reactions()
+                await ctx.send(spotify_url)
+
+    @commands.group(name="lastfm", aliases=["lf"])
+    async def _lastfm(self, ctx):
+        """Get Last.fm statistics of a user."""
+
+    @_lastfm.command(name="set")
+    async def _set(self, ctx, username: str):
+        """Set a username"""
+        method = "user.getInfo"
+        response = await self._api_request(method=method, username=username)
+        if "error" not in response:
+            await self.config.user(ctx.author).username.set(str(username))
+            message = _("Username set")
+        else:
+            message = response["message"]
+        await ctx.send(message)
+
+    @_lastfm.command(name="recent")
+    async def _recent(self, ctx):
+        """Shows recent tracks"""
+        username = await self.config.user(ctx.author).username()
+        limit = "10"
+        method = "user.getRecentTracks"
+        response = await self._api_request(
+            method=method, username=username, limit=limit
+        )
+        if "error" not in response:
+            user = response["recenttracks"]["@attr"]["user"]
+            author = ctx.author
+            text = ""
+            for i, track in enumerate(response["recenttracks"]["track"][:8], 1):
+                artist = track["artist"]["#text"]
+                song = track["name"]
+
+                url = await self._url_decode(track["url"])
+                artist = [artist if len(artist) < 25 else artist[:25] + "..."][0]
+                song = [song if len(song) < 25 else song[:25] + "..."][0]
+                text += _("`{}`{:<5}**[{}]({})** — **[{}]({})**\n").format(
+                    str(i),
+                    "",
+                    artist,
+                    "https://www.last.fm/music/{}".format(artist.replace(" ", "+")),
+                    song,
+                    url,
+                )
+            em = discord.Embed(description=text)
+            avatar = author.avatar_url if author.avatar else author.default_avatar_url
+            em.set_author(
+                name=_("{}'s Recent Tracks").format(user),
+                icon_url=avatar,
+                url="http://www.last.fm/user/{}/library".format(user),
+            )
+            await ctx.send(embed=em)
+        else:
+            message = response["message"]
+            await ctx.send(message)
+
+    @_lastfm.command(name="setreact")
+    @commands.guild_only()
+    @checks.mod()
+    async def _set_react(self, ctx, emote: str):
+        """Sets the emote for the now playing embed to view the Spotify link"""
+        async with self.config.guild(ctx.guild).emote() as guild_emote:
+            guild_emote = emote
+            await ctx.message.add_reaction(guild_emote)
+
+    # Helper functions
+
+    async def _api_request(
+        self,
+        method=None,
+        username=None,
+        limit=None,
+        artist=None,
+        track=None,
+        mbid=None,
+        autocorrect=None,
+    ):
         payload = self.payload
 
         if method:
-            payload['method'] = method
+            payload["method"] = method
         if username:
-            payload['username'] = username
+            payload["username"] = username
         if artist:
-            payload['artist'] = artist
+            payload["artist"] = artist
         if track:
-            payload['track'] = track
+            payload["track"] = track
         if limit:
-            payload['limit'] = int(limit)
+            payload["limit"] = int(limit)
         if autocorrect:
-            payload['autocorrect'] = autocorrect
+            payload["autocorrect"] = autocorrect
 
         session = aiohttp.ClientSession(connector=aiohttp.TCPConnector())
-        async with session.get(self.lf_gateway, params=payload) as r:        
+        async with session.get(self.lf_gateway, params=payload) as r:
             data = await r.json()
         await session.close()
         return data
@@ -81,144 +246,27 @@ class LastFM(BaseCog):
         this will wipe their saved username from the cog"""
         await self.config.user_from_id(user_id).clear()
 
-    async def _get_spotify_uri(self, track_url: str) -> str:
-        """Fetches the spotify URI from the LastFM track information page"""
-        async with aiohttp.ClientSession() as session:
-            async with session.get(track_url) as response:
-                page_text = await response.text()
-        page = Soup(page_text, 'html.parser')
+    async def _get_spotify_url(self, track_url: str) -> str:
+        """Fetches the spotify url from the LastFM track information page"""
         try:
-            spotify_uri = page.find("a", {"class": "play-this-track-playlink--spotify"}).get("href")
-        except AttributeError:
-            return None
-        return spotify_uri
-
-    # {
-    #   'servers': {
-    #               'youtube': false|true
-    #               },
-    #   'users': {
-    #               'id': 'username'
-    #            }
-    #
-    # }
-
-    @commands.command(name='nowplaying')
-    async def _nowplaying(self, ctx):
-        """Shows the current played song"""
-        username = await self.config.user(ctx.author).username()
-
-        if username == "":
-            return await ctx.send("You need to set a username first")
-
-        method = 'user.getRecentTracks'
-        limit = 1
-        response = await self._api_request(method=method, username=username, limit=limit) 
-        user = response['recenttracks']['@attr']['user']
-
-        if response['recenttracks']['track'] == []:
-            print(response['recenttracks']['track'])
-            return await ctx.send("{} is not playing anything, check to make sure you set the right lastfm username".format(user))
-
-        track = response['recenttracks']['track'][0]
-
-        if '@attr' not in track:
-            await ctx.send(_('{} is not playing any song right now').format(user))
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=2.0)
+            ) as session:
+                async with session.get(track_url) as response:
+                    page_text = await response.text()
+        except aiohttp.ServerTimeoutError:
             return
+        page = Soup(page_text, "html.parser")
+        try:
+            spotify_url = page.find(
+                "a", {"class": "play-this-track-playlink--spotify"}
+            ).get("href")
+        except AttributeError:
+            return
+        return spotify_url
 
-        if track['@attr']['nowplaying'] == 'true':
-            artist = track['artist']['#text']
-            artist_url = await self._url_decode('https://www.last.fm/music/{}'.format(artist.replace(' ', '+')))
-            song = track['name']
-            track_url = await self._url_decode(track['url'])
-
-            album = track['album']['#text']
-            album_url = await self._url_decode('https://www.last.fm/music/{}/{}'.format(artist.replace(' ', '+'), album.replace(' ', '+')))
-
-            image = track['image'][-1]['#text']
-            tags = await self._api_request(method='track.getTopTags', track=song, artist=artist, autocorrect=1)
-            trackinfo = await self._api_request(method='track.getInfo', track=song, artist=artist, username=username)
-
-            if 'error' not in tags:
-                tags = ', '.join(['[{}]({})'.format(tag['name'], tag['url']) for tag in tags['toptags']['tag'][:10]])
-            else:
-                tags = None
-
-            song = [song if len(song) < 18 else song[:18] + '...'][0]
-            artist = [artist if len(artist) < 18 else artist[:18] + '...'][0]
-            album = [album if len(album) < 18 else album[:18] + '...'][0]
-            spotify_uri = await self._get_spotify_uri(track_url)
-
-            em = discord.Embed()
-            em.set_thumbnail(url=image)
-            em.add_field(name=_('**Artist**'), value='[{}]({})'.format(artist, artist_url))
-            em.add_field(name=_('**Album**'), value='[{}]({})'.format(album, album_url))
-            em.add_field(name=_('**Track**'), value='[{}]({})'.format(song, track_url), inline=False)
-            
-            if tags:
-                em.add_field(name=_('**Tags**'), value=tags, inline=False)
-            
-            msg = await ctx.send(embed=em)
-
-            if not spotify_uri:
-                return
-
-            emote = await self.config.guild(ctx.guild).emote()
-            start_adding_reactions(msg, (emote))
-            predicate = ReactionPredicate.with_emojis((emote), msg)
-            reaction, user = await ctx.bot.wait_for("reaction_add", check=predicate)
-
-            if predicate.result == 0:
-                await ctx.send(f"{user.mention} {spotify_uri}")
-
-    @commands.group(name='lastfm', aliases=['lf'])
-    async def _lastfm(self, ctx):
-        """Get Last.fm statistics of a user."""
-
-    @_lastfm.command(name='set')
-    async def _set(self, ctx, username: str):
-        """Set a username"""
-        method = 'user.getInfo'
-        response = await self._api_request(method=method, username=username)
-        if 'error' not in response:
-            await self.config.user(ctx.author).username.set(str(username))
-            message = _('Username set')
-        else:
-            message = response['message']
-        await ctx.send(message)
-
-    @_lastfm.command(name='recent')
-    async def _recent(self, ctx):
-        """Shows recent tracks"""
-        username = await self.config.user(ctx.author).username()
-        limit = '10'
-        method = 'user.getRecentTracks'
-        response = await self._api_request(method=method, username=username, limit=limit)
-        if 'error' not in response:
-            user = response['recenttracks']['@attr']['user']
-            author = ctx.author
-            text = ''
-            for i, track in enumerate(response['recenttracks']['track'][:8], 1):
-                artist = track['artist']['#text']
-                song = track['name']
-
-                url = await self._url_decode(track['url'])
-                artist = [artist if len(artist) < 25 else artist[:25] + '...'][0]
-                song = [song if len(song) < 25 else song[:25] + '...'][0]
-                text += _('`{}`{:<5}**[{}]({})** — **[{}]({})**\n').format(str(i), '', artist, 'https://www.last.fm/music/{}'.format(artist.replace(' ', '+')), song, url)
-            em = discord.Embed(description=text)
-            avatar = author.avatar_url if author.avatar else author.default_avatar_url
-            em.set_author(name=_('{}\'s Recent Tracks').format(user), icon_url=avatar, url='http://www.last.fm/user/{}/library'.format(user))
-            await ctx.send(embed=em)
-        else:
-            message = response['message']
-            await ctx.send(message)
-
-    @_lastfm.command(name='setreact')
-    @commands.guild_only()
-    @checks.mod()
-    async def _set_react(self, ctx, emote: str):
-        """Sets the emote for the now playing embed to view the Spotify link"""
-        async with self.config.guild(ctx.guild).emote() as guild_emote:
-            guild_emote = emote
-            await ctx.message.add_reaction(guild_emote)
+    async def _url_decode(self, url):
+        # Fuck non-ascii URLs!!!@##$@
+        url = urllib.parse.urlparse(url)
+        url = "{0.scheme}://{0.netloc}{1}".format(url, urllib.parse.quote(url.path))
+        return url

--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -84,7 +84,7 @@ class LastFM(BaseCog):
         try:
             spotify_uri = page.find("a", {"class": "play-this-track-playlink--spotify"}).get("href")
         except AttributeError:
-            return ""
+            return None
         return spotify_uri
 
     # {
@@ -142,11 +142,9 @@ class LastFM(BaseCog):
                 em.add_field(name=_('**Album**'), value='[{}]({})'.format(album, album_url))
                 em.add_field(name="\u200B", value="\u200B") # Blank field
                 em.add_field(name=_('**Track**'), value='[{}]({})'.format(song, track_url))
-                if spotify_uri:
-                    em.add_field(name='**Spotify**', value='[Open with Spotify]({})'.format(spotify_uri))
                 if tags:
                     em.add_field(name=_('**Tags**'), value=tags, inline=False)
-                await ctx.send(embed=em)
+                await ctx.send(content=spotify_uri, embed=em)
         else:
             await ctx.send(_('{} is not playing any song right now').format(user))
 


### PR DESCRIPTION
When a user initiates the nowplaying command the bot will now add a reaction to the bot message which, when clicked, will send the spotify URL for the associated track.