### PR TITLE
[Lastfm] Add option to see details for other users

### DIFF
--- a/lastfm/info.json
+++ b/lastfm/info.json
@@ -1,5 +1,5 @@
 {
-  "author" : ["Paddo", "Kennnyshiwa"],
+  "author" : ["Issy", "Kennnyshiwa", "Paddo"],
   "bot_version" : [3, 0, 0],
   "description" : "Last.fm playing",
   "short" : "Get currently playing and recently played tracks from Last.fm",

--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -48,9 +48,11 @@ class LastFM(BaseCog):
     @commands.command(name="nowplaying")
     async def _nowplaying(self, ctx: commands.Context, member: discord.Member = None):
         """Shows the current played song"""
-        username = await self.config.user(ctx.author).username()
+        username = await self.config.user(member or ctx.author).username()
 
-        if not username:
+        if not username and member:
+            return await ctx.send(f"No username set for {member.display_name}")
+        elif not username:
             return await ctx.send("You need to set a username first")
 
         method = "user.getRecentTracks"
@@ -156,12 +158,11 @@ class LastFM(BaseCog):
     @_lastfm.command(name="recent")
     async def _recent(self, ctx: commands.Context, member: discord.Member = None):
         """Shows recent tracks"""
-        user = member or ctx.author
-        username = await self.config.user(user).username()
+        username = await self.config.user(member or ctx.author).username()
 
         if not username and member:
-            username = await self.config.user(ctx.author).username()
-        if not username:
+            return await ctx.send(f"No username set for {member.display_name}")
+        elif not username:
             return await ctx.send("You need to set a username first")
 
         limit = 10

--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -217,7 +217,7 @@ class LastFM(BaseCog):
         self,
         method: str = "",
         username: str = "",
-        limit: int = 0,
+        limit: int = None,
         artist: str = "",
         track: str = "",
         mbid=None,

--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -32,22 +32,25 @@ class LastFM(BaseCog):
     def __init__(self, bot):
         self.bot = bot
         self.config = Config.get_conf(self, 376564057517457408, force_registration=True)
+
         self.config.register_member(**self.default_member_settings)
         self.config.register_user(**self.default_user_settings)
         self.config.register_guild(**self.default_guild_settings)
 
         self.lf_gateway = "http://ws.audioscrobbler.com/2.0/"
 
-        self.payload = {}
-        self.payload["api_key"] = "c44979d5d86ff515ba9fba378c610474"
-        self.payload["format"] = "json"
+        self.payload = {"api_key": "c44979d5d86ff515ba9fba378c610474", "format": "json"}
+
+    @commands.group(name="lastfm", aliases=["lf"])
+    async def _lastfm(self, ctx):
+        """Get Last.fm statistics of a user."""
 
     @commands.command(name="nowplaying")
-    async def _nowplaying(self, ctx):
+    async def _nowplaying(self, ctx: commands.Context, member: discord.Member = None):
         """Shows the current played song"""
         username = await self.config.user(ctx.author).username()
 
-        if username == "":
+        if not username:
             return await ctx.send("You need to set a username first")
 
         method = "user.getRecentTracks"
@@ -107,7 +110,6 @@ class LastFM(BaseCog):
             song = [song if len(song) < 18 else song[:18] + "..."][0]
             artist = [artist if len(artist) < 18 else artist[:18] + "..."][0]
             album = [album if len(album) < 18 else album[:18] + "..."][0]
-            spotify_url = await self._get_spotify_url(track_url)
 
             em = discord.Embed()
             em.set_thumbnail(url=image)
@@ -126,6 +128,7 @@ class LastFM(BaseCog):
 
             msg = await ctx.send(embed=em)
 
+            spotify_url = await self._get_spotify_url(track_url)
             if not spotify_url:
                 return
 
@@ -137,10 +140,6 @@ class LastFM(BaseCog):
             if predicate.result == 0:
                 await msg.clear_reactions()
                 await ctx.send(spotify_url)
-
-    @commands.group(name="lastfm", aliases=["lf"])
-    async def _lastfm(self, ctx):
-        """Get Last.fm statistics of a user."""
 
     @_lastfm.command(name="set")
     async def _set(self, ctx, username: str):
@@ -155,10 +154,17 @@ class LastFM(BaseCog):
         await ctx.send(message)
 
     @_lastfm.command(name="recent")
-    async def _recent(self, ctx):
+    async def _recent(self, ctx, member: discord.Member = None):
         """Shows recent tracks"""
-        username = await self.config.user(ctx.author).username()
-        limit = "10"
+        user = member or ctx.author
+        username = await self.config.user(user).username()
+
+        if not username and member:
+            username = await self.config.user(ctx.author).username()
+        if not username:
+            return await ctx.send("You need to set a username first")
+
+        limit = 10
         method = "user.getRecentTracks"
         response = await self._api_request(
             method=method, username=username, limit=limit
@@ -199,23 +205,22 @@ class LastFM(BaseCog):
     @checks.mod()
     async def _set_react(self, ctx, emote: str):
         """Sets the emote for the now playing embed to view the Spotify link"""
-        async with self.config.guild(ctx.guild).emote() as guild_emote:
-            guild_emote = emote
-            await ctx.message.add_reaction(guild_emote)
+        await self.config.guild(ctx.guild).emote.set(emote)
+        await ctx.message.add_reaction(emote)
 
     # Helper functions
 
     async def _api_request(
         self,
-        method=None,
-        username=None,
-        limit=None,
-        artist=None,
-        track=None,
+        method: str = "",
+        username: str = "",
+        limit: int = 0,
+        artist: str = "",
+        track: str = "",
         mbid=None,
-        autocorrect=None,
+        autocorrect: int = None,
     ):
-        payload = self.payload
+        payload = self.payload.copy()
 
         if method:
             payload["method"] = method
@@ -226,14 +231,12 @@ class LastFM(BaseCog):
         if track:
             payload["track"] = track
         if limit:
-            payload["limit"] = int(limit)
+            payload["limit"] = limit
         if autocorrect:
             payload["autocorrect"] = autocorrect
 
-        session = aiohttp.ClientSession(connector=aiohttp.TCPConnector())
-        async with session.get(self.lf_gateway, params=payload) as r:
+        async with aiohttp.request("GET", self.lf_gateway, params=payload) as r:
             data = await r.json()
-        await session.close()
         return data
 
     async def red_delete_data_for_user(
@@ -249,11 +252,10 @@ class LastFM(BaseCog):
     async def _get_spotify_url(self, track_url: str) -> str:
         """Fetches the spotify url from the LastFM track information page"""
         try:
-            async with aiohttp.ClientSession(
-                timeout=aiohttp.ClientTimeout(total=2.0)
-            ) as session:
-                async with session.get(track_url) as response:
-                    page_text = await response.text()
+            async with aiohttp.request(
+                "GET", track_url, timeout=aiohttp.ClientTimeout(total=2.0)
+            ) as response:
+                page_text = await response.text()
         except aiohttp.ServerTimeoutError:
             return
         page = Soup(page_text, "html.parser")

--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -42,7 +42,7 @@ class LastFM(BaseCog):
         self.payload = {"api_key": "c44979d5d86ff515ba9fba378c610474", "format": "json"}
 
     @commands.group(name="lastfm", aliases=["lf"])
-    async def _lastfm(self, ctx):
+    async def _lastfm(self, ctx: commands.Context):
         """Get Last.fm statistics of a user."""
 
     @commands.command(name="nowplaying")
@@ -142,7 +142,7 @@ class LastFM(BaseCog):
                 await ctx.send(spotify_url)
 
     @_lastfm.command(name="set")
-    async def _set(self, ctx, username: str):
+    async def _set(self, ctx: commands.Context, username: str):
         """Set a username"""
         method = "user.getInfo"
         response = await self._api_request(method=method, username=username)
@@ -154,7 +154,7 @@ class LastFM(BaseCog):
         await ctx.send(message)
 
     @_lastfm.command(name="recent")
-    async def _recent(self, ctx, member: discord.Member = None):
+    async def _recent(self, ctx: commands.Context, member: discord.Member = None):
         """Shows recent tracks"""
         user = member or ctx.author
         username = await self.config.user(user).username()
@@ -203,10 +203,13 @@ class LastFM(BaseCog):
     @_lastfm.command(name="setreact")
     @commands.guild_only()
     @checks.mod()
-    async def _set_react(self, ctx, emote: str):
+    async def _set_react(self, ctx: commands.Context, emote: discord.Emoji):
         """Sets the emote for the now playing embed to view the Spotify link"""
-        await self.config.guild(ctx.guild).emote.set(emote)
-        await ctx.message.add_reaction(emote)
+        if (emote.guild and emote.guild == ctx.guild) or (not emote.guild):
+            await self.config.guild(ctx.guild).emote.set(emote)
+            await ctx.message.add_reaction(emote)
+        else:
+            
 
     # Helper functions
 
@@ -267,7 +270,7 @@ class LastFM(BaseCog):
             return
         return spotify_url
 
-    async def _url_decode(self, url):
+    async def _url_decode(self, url: str):
         # Fuck non-ascii URLs!!!@##$@
         url = urllib.parse.urlparse(url)
         url = "{0.scheme}://{0.netloc}{1}".format(url, urllib.parse.quote(url.path))


### PR DESCRIPTION
For the `nowplaying` and `recent` commands in the lastfm cog I've added a `member` argument that defaults to None. This allows you to do something like `[p]nowplaying @issy` and see what's currently playing for that person.
This won't break current functionality, as you are allowed to not specify a member.