### PR TITLE
Improve embed style

### DIFF
--- a/lastfm/lastfm.py
+++ b/lastfm/lastfm.py
@@ -109,16 +109,22 @@ class LastFM(BaseCog):
             else:
                 tags = None
 
-            song = [song if len(song) < 18 else song[:18] + "..."][0]
-            artist = [artist if len(artist) < 18 else artist[:18] + "..."][0]
-            album = [album if len(album) < 18 else album[:18] + "..."][0]
+            song = [song if len(song) < 32 else song[:32] + "..."][0]
+            artist = [artist if len(artist) < 32 else artist[:32] + "..."][0]
+            album = [album if len(album) < 32 else album[:32] + "..."][0]
 
             em = discord.Embed()
             em.set_thumbnail(url=image)
             em.add_field(
-                name=_("**Artist**"), value="[{}]({})".format(artist, artist_url)
+                name=_("**Artist**"),
+                value="[{}]({})".format(artist, artist_url),
+                inline=False,
             )
-            em.add_field(name=_("**Album**"), value="[{}]({})".format(album, album_url))
+            em.add_field(
+                name=_("**Album**"),
+                value="[{}]({})".format(album, album_url),
+                inline=False,
+            )
             em.add_field(
                 name=_("**Track**"),
                 value="[{}]({})".format(song, track_url),


### PR DESCRIPTION
* Increase max length of artist/album/track names from 18 to 32.  
This solves unnecessary truncation of almost any remixed track and/or "medium" length album name and/or multiple artists and/or long artist name. Agree with truncation on long strings, but 18 feels much too short.
* Split artist and album fields to separate lines

Example of embed with 32 character track name and 23 character album name:
![image](https://user-images.githubusercontent.com/10629864/158401745-07f50800-d85b-4bc4-8b58-8beccbc82202.png)

Example of same embed with artist and album fields not inline:
![image](https://user-images.githubusercontent.com/10629864/158402471-1001e761-8d0b-46c3-a929-09e24953d88e.png)

Example of embed with [what I think is] unnecessary truncation:
![image](https://user-images.githubusercontent.com/10629864/158401848-7d92c1ce-071b-4ca1-b27d-268d971411cf.png)

An argument could possibly even be made for allowing even more than 32 characters, especially given the proposed line break between artist and album fields, but I thought I'd go for what seems to be a safe middle ground here.

Feedback appreciated.